### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish_PYPI_each_tag.yml
+++ b/.github/workflows/publish_PYPI_each_tag.yml
@@ -4,6 +4,9 @@
 
 name: Upload Python Package
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [created]


### PR DESCRIPTION
Potential fix for [https://github.com/SiddhantSadangi/st_login_form/security/code-scanning/1](https://github.com/SiddhantSadangi/st_login_form/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily involves reading repository contents and does not modify the repository, the `contents: read` permission is sufficient. This permission will restrict the `GITHUB_TOKEN` to read-only access to the repository contents.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `deploy` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Restrict the GitHub Actions workflow to read-only repository permissions by adding a permissions block at the root level, addressing the code scanning security alert.

Bug Fixes:
- Fix code scanning alert by adding a permissions block to the GitHub Actions workflow.

CI:
- Add contents: read permission at the root of publish_PYPI_each_tag workflow to restrict GITHUB_TOKEN to read-only repository access.